### PR TITLE
docs: clarify Smart Empties contributing scope (beta, no PRs)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,41 @@
 # Contributing
 
-Thanks for your interest!
+Thanks for your interest in Smart Empties.
 
-## Workflow
-- Create a topic branch from `main`.
-- Make changes, write clear commits.
-- Open a Pull Request (PR).
+## Scope of This Repository
+
+This repository is used for:
+
+- Beta release distribution
+- Issue tracking
+- Bug reports
+- Feature requests
+- Public changelog and release notes
+
+It is not the primary development repository.
+
+## Code Contributions
+
+At this time, this repository does not accept external code contributions or pull requests.
+
+Smart Empties is actively developed under a controlled studio workflow to maintain architectural consistency, UX standards, and release discipline.
+
+If you would like to suggest improvements or report issues, please open an Issue instead.
+
+We may revisit external code contributions after a stable v1 release.
+
+## Reporting Issues
+
+When submitting a bug report, please include:
+
+- Blender version
+- Operating system
+- Smart Empties version
+- Clear reproduction steps
+- Screenshots or screen recordings if possible
+
+Clear reports help us resolve issues quickly.
 
 ## Code of Conduct
-By participating, you agree to abide by the Code of Conduct in this repo.
+
+By participating in this repository, you agree to follow the Code of Conduct.


### PR DESCRIPTION
Define repository scope as beta distribution and issue tracking.
Disable external code contributions to maintain controlled studio workflow.
