### PR TITLE
docs: align README title with MØDLR Tools suite naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Smart Empties · MØDLR SMART Tools
+# Smart Empties · MØDLR Tools
 
 Precision empty placement and management for Blender — **fast, deterministic, and undo-safe**.<br>
 Part of the **MØDLR SMART Tools** suite.<br>


### PR DESCRIPTION
Updated README header to use "Smart Empties · MØDLR Tools" for suite consistency.

No functional changes.